### PR TITLE
Announce plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ If the bot doesn't find _AFK_ channel, it will try to create one.
 You can white/blacklist channels where clients can be moved from.
 If you have _Jail_ plugin enabled, You might want to add your jail channel to the blacklist.
 
+### 📣 Announce
+
+Announce a message to clients by poking them.  
+You can announce to a specific group or to all clients.
+
+- `announce "Hello all"`: Pokes all clients with a message "Hello all"
+- `announce "Team meeting now!" Staff`: Pokes clients in "Staff" server group with "Team meeting now!"
+
 ### ⛔ Banned names
 
 Kicks out any clients with configured nickname.  
@@ -140,6 +148,16 @@ Plugin config key: `afk_mover`
 | idle_time | `float` | AFK grace period in seconds |
 | channel_whitelist | `tuple[str, ...]` | Channel names where clients will be moved. |
 | channel_blacklist | `tuple[str, ...]` | Channel names where clients wont be moved. |
+
+### Announce
+
+Plugin config key: `announce`
+| Key | Type | Explanation |
+|---|---|---|
+| enabled | `bool` | If the plugin is enabled |
+| allowed_uids | `tuple[str, ...]` | UIDs allowed to run announce commands. |
+| allowed_server_groups | `tuple[str, ...]` | Server groups allowed to run announce commands. |
+| strict_server_group_checking | `bool` | Match server groups strictly |
 
 ### Banned Names
 

--- a/teamspeak_bot/bot.py
+++ b/teamspeak_bot/bot.py
@@ -14,6 +14,7 @@ from teamspeak_bot.logging import setup_logger
 from teamspeak_bot.plugins import (
     admin,
     afk_mover,
+    announce,
     banned_names,
     error_events,
     fun,
@@ -98,6 +99,9 @@ def main() -> NoReturn:
 
         if (afk_config := plugins_config.get("afk_mover")) and afk_config.get("enabled"):
             bot.load_plugin(afk_mover.AFKMover(afk_config))
+
+        if (announce_config := plugins_config.get("announce")) and announce_config.get("enabled"):
+            bot.load_plugin(announce.AnnouncementPlugin(bot, announce_config))
 
         if (names_config := plugins_config.get("banned_names")) and names_config.get("enabled"):
             bot.load_plugin(banned_names.BannedNamesPlugin(bot, names_config))

--- a/teamspeak_bot/config.py
+++ b/teamspeak_bot/config.py
@@ -10,6 +10,7 @@ from result import Err, Ok, Result
 from teamspeak_bot.plugins import (
     admin,
     afk_mover,
+    announce,
     banned_names,
     error_events,
     fun,
@@ -29,6 +30,7 @@ class LoggingConfig(TypedDict, total=False):
 class PluginsConfig(TypedDict, total=False):
     admin: admin.AdminConfig
     afk_mover: afk_mover.AFKMoverConfig
+    announce: announce.AnnouncementConfig
     banned_names: banned_names.BannedNamesConfig
     error_events: error_events.ErrorEventsConfig
     fun: fun.FunConfig
@@ -67,6 +69,7 @@ class BotConfig(RequiredFields, OptionalFields, total=False):
 DEFAULT_PLUGINS_CONFIG: Final[PluginsConfig] = {
     "admin": admin.DEFAULT_CONFIG,
     "afk_mover": afk_mover.DEFAULT_CONFIG,
+    "announce": announce.DEFAULT_CONFIG,
     "banned_names": banned_names.DEFAULT_CONFIG,
     "error_events": error_events.DEFAULT_CONFIG,
     "fun": fun.DEFAULT_CONFIG,

--- a/teamspeak_bot/plugins/admin.py
+++ b/teamspeak_bot/plugins/admin.py
@@ -58,7 +58,7 @@ class AdminPlugin(plugin.TSPlugin):
 
     async def send(self, bot: TSBot, ctx: TSCtx, raw_command: str) -> None:
         response = await try_.async_or_call(
-            bot.send_raw(raw_command), lambda e: f"{type(e).__name__}: {e}"
+            bot.send_raw(raw_command), on_error=lambda e: f"{type(e).__name__}: {e}"
         )
 
         await bot.respond(ctx, repr(response) if isinstance(response, TSResponse) else response)

--- a/teamspeak_bot/plugins/afk_mover.py
+++ b/teamspeak_bot/plugins/afk_mover.py
@@ -113,7 +113,12 @@ class AFKMover(plugin.TSPlugin):
     async def get_afk_channel(self, bot: TSBot) -> str:
         channel_list = await cache.with_cache(bot.send, CHANNEL_LIST_QUERY, max_ttl=60)
 
-        channel_id = find.from_iterable(channel_list, self.afk_channel, "channel_name", "cid")
+        channel_id = find.from_iterable(
+            channel_list,
+            search=self.afk_channel,
+            key="channel_name",
+            result="cid",
+        )
         if not channel_id:
             channel_id = await self.create_afk_channel(bot)
 

--- a/teamspeak_bot/plugins/announce.py
+++ b/teamspeak_bot/plugins/announce.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from result import Err, Ok, Result, as_async_result
+from tsbot import plugin, query
+from tsbot.exceptions import TSCommandError, TSResponseError
+
+from teamspeak_bot.common import CLIENT_LIST_QUERY
+from teamspeak_bot.plugins import BasePluginConfig
+from teamspeak_bot.utils import cache, checks, find
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from tsbot import TSBot, TSCtx
+
+
+class AnnouncementConfig(BasePluginConfig):
+    allowed_uids: tuple[str, ...]
+    allowed_server_groups: tuple[str, ...]
+    strict_server_group_checking: bool
+
+
+DEFAULT_CONFIG = AnnouncementConfig(
+    enabled=True,
+    allowed_uids=(),
+    allowed_server_groups=("Server Admin",),
+    strict_server_group_checking=False,
+)
+
+
+class AnnouncementPlugin(plugin.TSPlugin):
+    def __init__(self, bot: TSBot, config: AnnouncementConfig) -> None:
+        announce_check = (
+            checks.check_uids_and_server_groups(
+                uids=config.get("allowed_uids"),
+                server_groups=config.get("allowed_server_groups"),
+                strict=config.get("strict_server_group_checking", False),
+            ),
+        )
+
+        bot.register_command("announce", self.announce, checks=announce_check)
+
+    async def _get_server_group_clients(
+        self, bot: TSBot, group: str, clients: Iterable[Mapping[str, str]]
+    ) -> Result[Iterable[Mapping[str, str]], str]:
+        server_groups = await bot.send(query("servergrouplist"))
+
+        group_id = find.from_iterable(
+            server_groups,
+            search=group,
+            key="name",
+            result="sgid",
+            predicate=lambda g: g["type"] == "1",
+        )
+
+        if group_id is None:
+            return Err("No such group")
+
+        server_group_clientlist = await as_async_result(TSResponseError)(bot.send)(
+            query("servergroupclientlist").params(sgid=group_id)
+        )
+
+        if isinstance(server_group_clientlist, Err):
+            return server_group_clientlist.map_err(lambda e: str(e))
+
+        server_group_clients = {client["cldbid"] for client in server_group_clientlist.unwrap()}
+        return Ok(filter(lambda c: c["client_database_id"] in server_group_clients, clients))
+
+    async def announce(self, bot: TSBot, ctx: TSCtx, message: str, group: str = "all") -> None:
+        client_list = await cache.with_cache(bot.send, CLIENT_LIST_QUERY)
+        poke_query = query("clientpoke").params(msg=message)
+
+        if group != "all":
+            client_list = (
+                await self._get_server_group_clients(bot, group, client_list)
+            ).unwrap_or_raise(TSCommandError)
+
+        await bot.send_batched(poke_query.params(clid=c["clid"]) for c in client_list)

--- a/teamspeak_bot/plugins/announce.py
+++ b/teamspeak_bot/plugins/announce.py
@@ -25,7 +25,7 @@ class AnnouncementConfig(BasePluginConfig):
 DEFAULT_CONFIG = AnnouncementConfig(
     enabled=True,
     allowed_uids=(),
-    allowed_server_groups=("Server Admin",),
+    allowed_server_groups=("Admin",),
     strict_server_group_checking=False,
 )
 

--- a/teamspeak_bot/plugins/greeter.py
+++ b/teamspeak_bot/plugins/greeter.py
@@ -8,7 +8,7 @@ from tsbot.exceptions import TSException, TSResponseError
 
 from teamspeak_bot.common import SERVER_GROUPS_QUERY
 from teamspeak_bot.plugins import BasePluginConfig
-from teamspeak_bot.utils import cache
+from teamspeak_bot.utils import cache, find
 
 if TYPE_CHECKING:
     from tsbot import TSBot, TSCtx
@@ -38,10 +38,13 @@ class GreeterPlugin(plugin.TSPlugin):
     async def get_guest_id(self, bot: TSBot, ctx: None) -> None:
         server_groups = await cache.with_cache(bot.send, SERVER_GROUPS_QUERY, max_ttl=60)
 
-        guest_id = None
-        for group in server_groups:
-            if group["name"] == "Guest" and group["type"] == "1":
-                guest_id = group["sgid"]
+        guest_id = find.from_iterable(
+            server_groups,
+            search="Guest",
+            key="name",
+            result="sgid",
+            predicate=lambda g: g["type"] == "1",
+        )
 
         if not guest_id:
             raise TSException("Failed to find 'Guest' server id")

--- a/teamspeak_bot/plugins/jail.py
+++ b/teamspeak_bot/plugins/jail.py
@@ -77,7 +77,12 @@ class JailPlugin(plugin.TSPlugin):
     async def get_jail_channel_id(self, bot: TSBot) -> str:
         channel_list = await cache.with_cache(bot.send, CHANNEL_LIST_QUERY, max_ttl=60)
 
-        channel_id = find.from_iterable(channel_list, self.jail_channel, "channel_name", "cid")
+        channel_id = find.from_iterable(
+            channel_list,
+            search=self.jail_channel,
+            key="channel_name",
+            result="cid",
+        )
         if not channel_id:
             channel_id = await self.create_jail_channel(bot)
 
@@ -95,7 +100,12 @@ class JailPlugin(plugin.TSPlugin):
     async def get_inmate_server_group_id(self, bot: TSBot) -> str:
         server_groups_list = await cache.with_cache(bot.send, SERVER_GROUPS_QUERY, max_ttl=60)
 
-        inmate_id = find.from_iterable(server_groups_list, self.inmate_name, "name", "sgid")
+        inmate_id = find.from_iterable(
+            server_groups_list,
+            search=self.inmate_name,
+            key="name",
+            result="sgid",
+        )
         if inmate_id is None:
             inmate_id = await self.create_inmate_server_group(bot)
 
@@ -139,7 +149,7 @@ class JailPlugin(plugin.TSPlugin):
 
         client_list = await bot.send(query("clientlist").option("groups"))
 
-        client = find.from_iterable(client_list, nickname, "client_nickname")
+        client = find.from_iterable(client_list, search=nickname, key="client_nickname")
         if client is None:
             raise TSCommandError("No client found")
 
@@ -153,7 +163,7 @@ class JailPlugin(plugin.TSPlugin):
     async def free(self, bot: TSBot, ctx: TSCtx, nickname: str) -> None:
         client_list = await bot.send(query("clientlist").option("groups"))
 
-        client = find.from_iterable(client_list, nickname, "client_nickname")
+        client = find.from_iterable(client_list, search=nickname, key="client_nickname")
         if client is None:
             raise TSCommandError("No client found")
 

--- a/teamspeak_bot/utils/cache.py
+++ b/teamspeak_bot/utils/cache.py
@@ -52,7 +52,7 @@ _cache_locks: defaultdict[Any, asyncio.Lock] = defaultdict(asyncio.Lock)
 
 
 async def with_cache[T, *Ts](
-    func: Callable[[*Ts], Coroutine[None, None, T]], *args: *Ts, max_ttl: int
+    func: Callable[[*Ts], Coroutine[None, None, T]], *args: *Ts, max_ttl: int = 0
 ) -> T:
     async with _cache_locks[args]:
         _cache.purge()

--- a/teamspeak_bot/utils/find.py
+++ b/teamspeak_bot/utils/find.py
@@ -4,43 +4,46 @@ import operator
 from typing import TYPE_CHECKING, overload
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Callable, Iterable, Mapping
 
 
 @overload
 def from_iterable[K: str, V: str](
-    search_list: Iterable[Mapping[K, V]],
-    search_str: str,
-    search_attr: K,
-    result_attr: None = None,
+    haystack: Iterable[Mapping[K, V]],
+    search: str,
+    key: K,
+    result: None = None,
     *,
     strict: bool = False,
+    predicate: Callable[[Mapping[K, V]], bool] | None = None,
 ) -> Mapping[K, V] | None: ...
 
 
 @overload
 def from_iterable[K: str, V: str](
-    search_list: Iterable[Mapping[K, V]],
-    search_str: str,
-    search_attr: K,
-    result_attr: K,
+    haystack: Iterable[Mapping[K, V]],
+    search: str,
+    key: K,
+    result: K,
     *,
     strict: bool = False,
+    predicate: Callable[[Mapping[K, V]], bool] | None = None,
 ) -> V | None: ...
 
 
 def from_iterable[K: str, V: str](
-    search_list: Iterable[Mapping[K, V]],
-    search_str: str,
-    search_attr: K,
-    result_attr: K | None = None,
+    haystack: Iterable[Mapping[K, V]],
+    search: str,
+    key: K,
+    result: K | None = None,
     *,
     strict: bool = False,
+    predicate: Callable[[Mapping[K, V]], bool] | None = None,
 ) -> V | Mapping[K, V] | None:
     op = operator.eq if strict else operator.contains
 
-    for item in search_list:
-        if op(item[search_attr], search_str):
-            return item[result_attr] if result_attr else item
+    for item in haystack:
+        if op(item[key], search) and predicate(item) if predicate else True:
+            return item[result] if result else item
 
     return None

--- a/teamspeak_bot/utils/try_.py
+++ b/teamspeak_bot/utils/try_.py
@@ -29,6 +29,13 @@ def or_call[T, TD, *Ts](
         return on_error(e)
 
 
+async def async_or_none[T](func: Coroutine[None, None, T]) -> T | None:
+    try:
+        return await func
+    except Exception:
+        return None
+
+
 async def async_or_call[T, TD](
     func: Coroutine[None, None, T], on_error: Callable[[Exception], TD]
 ) -> T | TD:

--- a/teamspeak_bot/utils/try_.py
+++ b/teamspeak_bot/utils/try_.py
@@ -37,7 +37,7 @@ async def async_or_none[T](func: Coroutine[None, None, T]) -> T | None:
 
 
 async def async_or_call[T, TD](
-    func: Coroutine[None, None, T], on_error: Callable[[Exception], TD]
+    func: Coroutine[None, None, T], *, on_error: Callable[[Exception], TD]
 ) -> T | TD:
     try:
         return await func


### PR DESCRIPTION
Adds a plugin to to poke clients with a message.

You can specify a server group or all clients.

Example usage:
* `!announce "Hello all"`: Pokes all clients with a message "Hello all"
* `!announce "Team meeting now!" Staff`: pokes clients in "Staff" server group with "Team meeting now!"
* `!announce "SHAME YOU!" -group Inmate`: Same thing as ^^^ but for Inmates

You can specify server groups and/or uids that can use this command.

Default config:
```python
DEFAULT_CONFIG = AnnouncementConfig(
    enabled=True,
    allowed_uids=(),
    allowed_server_groups=("Admin",),
    strict_server_group_checking=False,
)
```